### PR TITLE
Fix typo abstact/abstract

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -35,8 +35,8 @@ function fetchRSS($atts) {
 			$handlePaper = $url[count($url)-1];
 			$title = preg_replace('!\s+!', ' ', $item->get_title());
 			$authors = "";
-			$abstact = "";
-			
+			$abstract = "";
+
 			if ($excerpt != false && $excerpt != "false") {
 				$desc = $item->get_description();
 				$iAuthors = strpos($desc,"Authors:",0);


### PR DESCRIPTION
This is a fix for a simple typo which causes a PHP notice when $excerpt is false.
